### PR TITLE
[_] refactor(mongo-upgrade): remove callbacks from queries

### DIFF
--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -58,7 +58,7 @@ AuthenticateMiddlewareFactory._basic = function(storage, req, res, next) {
   });
 };
 
-AuthenticateMiddlewareFactory._ecdsa = function(storage, req, res, next) {
+AuthenticateMiddlewareFactory._ecdsa = async function(storage, req, res, next) {
   if (!AuthenticateMiddlewareFactory._verifySignature(req)) {
     return next(new errors.NotAuthorizedError('Invalid signature'));
   }
@@ -67,12 +67,10 @@ AuthenticateMiddlewareFactory._ecdsa = function(storage, req, res, next) {
   const User = storage.models.User;
   const UserNonce = storage.models.UserNonce;
 
-  PublicKey.findOne({
-    _id: req.header('x-pubkey')
-  }).exec(function(err, pubkey) {
-    if (err) {
-      return next(err);
-    }
+  try {
+    const pubkey = await PublicKey.findOne({
+      _id: req.header('x-pubkey')
+    });
 
     if (!pubkey) {
       return next(new errors.NotAuthorizedError(
@@ -82,40 +80,39 @@ AuthenticateMiddlewareFactory._ecdsa = function(storage, req, res, next) {
 
     let params = AuthenticateMiddlewareFactory._getParams(req);
 
-    User.findOne({ _id: pubkey.user }, function(err, user) {
-      if (err) {
-        return next(err);
-      }
+    const user = await User.findOne({ _id: pubkey.user });
 
-      if (!user) {
-        return next(new errors.NotAuthorizedError('User not found'));
-      }
+    if (!user) {
+      return next(new errors.NotAuthorizedError('User not found'));
+    }
 
-      if (!user.activated) {
-        return next(new errors.ForbiddenError(
-          'User account has not been activated'
+    if (!user.activated) {
+      return next(new errors.ForbiddenError(
+        'User account has not been activated'
+      ));
+    }
+
+    var userNonce = new UserNonce({
+      user: user.id,
+      nonce: params.__nonce
+    });
+
+    try {
+      await userNonce.save();
+      req.user = user;
+      req.pubkey = pubkey;
+      return next();
+    } catch (err) {
+      if (err.code === 11000) {
+        return next(new errors.NotAuthorizedError(
+          'Invalid nonce supplied'
         ));
       }
-
-      var userNonce = new UserNonce({
-        user: user.id,
-        nonce: params.__nonce
-      });
-
-      userNonce.save(function(err) {
-        if (err && err.code === '11000') {
-          return next(new errors.NotAuthorizedError(
-            'Invalid nonce supplied'
-          ));
-        }
-
-        req.user = user;
-        req.pubkey = pubkey;
-
-        return next(err);
-      });
-    });
-  });
+      return next(err);
+    }
+  } catch (err) {
+    return next(err);
+  }
 
 }
 

--- a/lib/public-bucket.js
+++ b/lib/public-bucket.js
@@ -12,22 +12,23 @@ module.exports = function PublicBucketFactory(storage){
    * @param {String} req.params.id - Unique bucket id
    * @param {String} req.body.operation - Operation to perform
    */
-  return function publicBucket(req, res, next) {
+  return async function publicBucket(req, res, next) {
     var bucketId = req.params.id;
     var operation = req.body.operation || 'PULL';
 
-    Bucket.findOne({
-      _id: req.params.id,
-      publicPermissions: { $in: [operation] }
-    }, function(err, bucket){
-      if(err){
-        return next(err);
-      }
+    try {
+      const bucket = await Bucket.findOne({
+        _id: req.params.id,
+        publicPermissions: { $in: [operation] }
+      });
+      
       if(!bucket){
         return next(new Error('Bucket not found'));
       }
       next(null);
-    });
+    } catch(err) {
+      return next(err);
+    }
 
   };
 


### PR DESCRIPTION
Mongoose 7 moved to promises. We need to stop using callbacks when querying as any query using callback will throw.

This PR changes callbacks to async await and nothing more.